### PR TITLE
use loadPerson post-create for DRYness

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -74,7 +74,7 @@ export default class Game extends Component {
   createPerson () {
     const personId = 'fresh'
     ipcRenderer.on('person--create:reply', (event, person) => {
-      this.setState({ personId, person })
+      this.loadPerson(personId)
     })
     ipcRenderer.send('person--create', personId)
   }

--- a/src/renderer-events/index.js
+++ b/src/renderer-events/index.js
@@ -1,12 +1,14 @@
 import { ipcMain } from 'electron'
 import { readdir, readFile, writeFile, unlink } from 'fs'
-import { join, basename } from 'path'
+import { join, basename, extname } from 'path'
 
 ipcMain.on('people--load', (event) => {
   const dir = join(__dirname, '..', 'people')
   readdir(dir, (err, people) => {
-    const names = people.map((person) => {
-      return basename(person).split('.json')[0]
+    const names = people.filter((person) => {
+      return extname(person) === '.json'
+    }).map((person) => {
+      return basename(person, '.json')
     })
     event.sender.send('people--load:reply', names)
   })
@@ -15,7 +17,6 @@ ipcMain.on('people--load', (event) => {
 ipcMain.on('person--load', (event, personId) => {
   const file = join(__dirname, '..', 'people', `${personId}.json`)
   readFile(file, 'utf8', (err, person) => {
-    // console.log(JSON.stringify(person, null, 2))
     event.sender.send('person--load:reply', person)
   })
 })


### PR DESCRIPTION
This solves a bug wherein we'd have to reload the page to play through a freshly created story.