### PR TITLE
updated to stable version of electron-prebuilt-compile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -550,7 +550,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000804",
+        "caniuse-db": "1.0.30000808",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -563,7 +563,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000804",
+            "caniuse-db": "1.0.30000808",
             "electron-to-chromium": "1.3.33"
           }
         }
@@ -1638,7 +1638,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000804",
+        "caniuse-db": "1.0.30000808",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       },
@@ -1649,16 +1649,16 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000804",
+            "caniuse-db": "1.0.30000808",
             "electron-to-chromium": "1.3.33"
           }
         }
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000804",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000804.tgz",
-      "integrity": "sha1-hP60IBj8ZM9q/2Nx5DEV8pLAAXk=",
+      "version": "1.0.30000808",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000808.tgz",
+      "integrity": "sha1-MN/YMAnVcE8C3/s3clBo7RKjZrs=",
       "dev": true
     },
     "caniuse-lite": {
@@ -3367,34 +3367,34 @@
       }
     },
     "electron-prebuilt-compile": {
-      "version": "1.8.2-beta.3",
-      "resolved": "https://registry.npmjs.org/electron-prebuilt-compile/-/electron-prebuilt-compile-1.8.2-beta.3.tgz",
-      "integrity": "sha512-SHca2lwcBJB1l2bKjX3uNmZKUJZYg4fTi1zmbjegbThQfA49U+cJSHBA/P3A0LbBQislHtB8p003b26trld2iA==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/electron-prebuilt-compile/-/electron-prebuilt-compile-1.8.2.tgz",
+      "integrity": "sha512-wiDVjy8S0PA/K/TUM0lw5gzZ+SmyVVGQ0qt9iFYXHJc6t8TzDXFY3DsoK37H3A7nWnkvXvoPdpJ5/h9KbTMoAw==",
       "dev": true,
       "requires": {
         "babel-plugin-array-includes": "2.0.3",
         "babel-plugin-transform-async-to-generator": "6.24.1",
         "babel-preset-es2016-node5": "1.1.2",
         "babel-preset-react": "6.24.1",
-        "electron": "1.8.2-beta.3",
+        "electron": "1.8.2",
         "electron-compile": "6.4.2",
         "electron-compilers": "5.9.0",
         "yargs": "6.6.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.9.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.0.tgz",
-          "integrity": "sha512-LVPrm5uzrma9ThwNiCgXWtsiXgPgUyEBzJJUJ8zcY0z/Dfdwa1mZ6PR51/mTKourRKnpEx/gwDHYUiY0Z/Juzg==",
+          "version": "8.9.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.9.3.tgz",
+          "integrity": "sha512-wqrPE4Uvj2fmL0E5JFQiY7D/5bAKvVUfWTnQ5NEV35ULkAU0j3QuqIi9Qyrytz8M5hsrh8Kijt+FsdLQaZR+IA==",
           "dev": true
         },
         "electron": {
-          "version": "1.8.2-beta.3",
-          "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.2-beta.3.tgz",
-          "integrity": "sha1-Ljkcy9YnaKOzsmC48uPxZHNWeuw=",
+          "version": "1.8.2",
+          "resolved": "https://registry.npmjs.org/electron/-/electron-1.8.2.tgz",
+          "integrity": "sha512-0TV5Hy92g8ACnPn+PVol6a/2uk+khzmRtWxhah/FcKs6StCytm5hD14QqOdZxEdJN8HljXIVCayN/wJX+0wDiQ==",
           "dev": true,
           "requires": {
-            "@types/node": "8.9.0",
+            "@types/node": "8.9.3",
             "electron-download": "3.3.0",
             "extract-zip": "1.6.6"
           }
@@ -7544,7 +7544,7 @@
           "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
           "dev": true,
           "requires": {
-            "caniuse-db": "1.0.30000804",
+            "caniuse-db": "1.0.30000808",
             "electron-to-chromium": "1.3.33"
           }
         }
@@ -8636,7 +8636,7 @@
         "buffer-crc32": "0.2.13",
         "minimist": "1.2.0",
         "sander": "0.5.1",
-        "sourcemap-codec": "1.3.1"
+        "sourcemap-codec": "1.4.0"
       },
       "dependencies": {
         "minimist": {
@@ -8679,12 +8679,12 @@
       }
     },
     "sourcemap-codec": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.3.1.tgz",
-      "integrity": "sha1-mtb5vb1pGTEBbjCTnbyGhnMyMUY=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.0.tgz",
+      "integrity": "sha512-66s3CwUASiYGiwQxkr34IctPs/LDkaJ8qNqVK6bBektymq3Sx1rX9qDZ8MNXFwiXqKuM3JYwzG3NAhI1ivqkjA==",
       "dev": true,
       "requires": {
-        "vlq": "0.2.3"
+        "vlq": "1.0.0"
       }
     },
     "sourcemapped-stacktrace": {
@@ -9835,9 +9835,9 @@
       }
     },
     "vlq": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
-      "integrity": "sha512-DRibZL6DsNhIgYQ+wNdWDL2SL3bKPlVrRiBqV5yuMm++op8W4kGFtaQfCs4KEJn0wBZcHVHJ3eoywX8983k1ow==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-1.0.0.tgz",
+      "integrity": "sha512-o3WmXySo+oI5thgqr7Qy8uBkT/v9Zr+sRyrh1lr8aWPUkgDWdWt4Nae2WKBrLsocgE8BuWWD0jLc+VW8LeU+2g==",
       "dev": true
     },
     "void-elements": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "electron-forge": "^4.2.0",
-    "electron-prebuilt-compile": "1.8.2-beta.3",
+    "electron-prebuilt-compile": "1.8.2",
     "eslint": "^3",
     "eslint-config-airbnb": "^15",
     "eslint-plugin-import": "^2",


### PR DESCRIPTION
1.8.2-beta.3 had a bug that crashed Electron when typing into DevTools. This updates to the latest stable version of Electron.