### PR TITLE
Removed duplicate instance of ConversationNode in navigator.js

### DIFF
--- a/src/components/conversation/navigator.js
+++ b/src/components/conversation/navigator.js
@@ -153,7 +153,6 @@ class Screen extends Component {
               <g className="GraphicalNodes">{graphicalNodes}</g>
             </g>
           </g>
-          <g className="ConversationNodes">{conversationNodes}</g>
           {storylineMode ? null : (
             <g className="ConversationNodes">{conversationNodes}</g>
           )}


### PR DESCRIPTION
When I was updating prop types the Click Here message when cycling through the messages and it was killing me.

From what I saw, the conversation node in the `<g>` tag was being rendered twice. While the 2nd one was being toggled by the inline conditional, the first remained unchanged. I removed the static version and the issue went away.