### PR TITLE
brought tree to front and added click functionality

### DIFF
--- a/src/components/book/index.js
+++ b/src/components/book/index.js
@@ -102,7 +102,6 @@ class Book extends Component {
   }
   render() {
     // eslint-disable-next-line no-console
-    console.log(this.props.location)
     if (this.state.loading) return <h1>'LOADING'</h1>
     else if (this.props.match.params.nodeId) return this.renderPages()
     return this.renderRedirect()

--- a/src/components/book/index.js
+++ b/src/components/book/index.js
@@ -102,6 +102,7 @@ class Book extends Component {
   }
   render() {
     // eslint-disable-next-line no-console
+    console.log(this.props.location)
     if (this.state.loading) return <h1>'LOADING'</h1>
     else if (this.props.match.params.nodeId) return this.renderPages()
     return this.renderRedirect()

--- a/src/components/graphical-node/index.js
+++ b/src/components/graphical-node/index.js
@@ -4,6 +4,7 @@ const styled = require('styled-components').default
 const PropTypes = require('prop-types')
 
 const { guid, node } = require('../../validators')
+const qs = require('qs')
 
 const Circle = styled.circle`
   fill: #f09;
@@ -69,6 +70,17 @@ class GraphicalNode extends Component {
               },
             }
             this.props.onDragBegin(dragState)
+          }}
+          onClick={(e) => {
+            if (!this.props.dragging) {
+              const { storyId, node } = this.props
+              const search = qs.parse(this.props.location.search.substring(1))
+              const to = {
+                pathname: `/story/${storyId}/node/${node.id}`,
+                search: `?${qs.stringify(search, { encode: false })}`,
+              }
+              this.props.history.push(to)
+            }
           }}
           r={20}
         />

--- a/src/components/page/index.js
+++ b/src/components/page/index.js
@@ -119,6 +119,8 @@ class Page extends Component {
         storyId={this.props.storyId}
         dragging={this.state.dragging}
         onDragEnd={this.handleDragEnd}
+        history={this.props.history}
+        location={this.props.location}
         key={`graphical-${i}`}
         node={n}
         zoom={zoomY}

--- a/src/components/stage/index.js
+++ b/src/components/stage/index.js
@@ -23,7 +23,7 @@ class Illustration extends PureComponent {
         <Scaler
           naturalLinks={this.props.naturalLinks}
           additionalLinks={this.props.additionalLinks}
-          graphicalNodesnks={this.props.graphicalNodes}
+          graphicalNodes={this.props.graphicalNodes}
         />
       </g>
     )
@@ -34,14 +34,14 @@ class Stage extends PureComponent {
   render() {
     return (
       <g className="Stage">
+        {this.props.children}
         <Illustration
           transX={this.props.transX}
           transY={this.props.transY}
           naturalLinks={this.props.naturalLinks}
           additionalLinks={this.props.additionalLinks}
-          graphicalNodesnks={this.props.graphicalNodes}
+          graphicalNodes={this.props.graphicalNodes}
         />
-        {this.props.children}
       </g>
     )
   }


### PR DESCRIPTION
Ok, I redid the functionality here with the most updated version. The tree needs to be rendered last so it is accessible, so I flipped the order of `TextNode` and `GraphicalNode`. Click handler was added to the nodes as well. We have to change the zoom to make this useful - if you go to the 2nd level you can see how it works.